### PR TITLE
Moved score behavior into collab style

### DIFF
--- a/internal/co_coders/criteria/collab_style.go
+++ b/internal/co_coders/criteria/collab_style.go
@@ -2,6 +2,8 @@ package criteria
 
 // CollabStyle ..
 type CollabStyle int
+
+// CollabStyle Constants
 const (
 	Team CollabStyle = iota + 1
 	Pair
@@ -21,13 +23,31 @@ func (c CollabStyles) HasCollabStyle(collabStyle CollabStyle) bool {
 	return false
 }
 
+// CollabStylesMatch ..
+type CollabStylesMatch struct {
+	Matches CollabStyles
+	Score   float64
+}
+
 // Match ..
-func (c CollabStyles) Match(stylesToMatch CollabStyles) (matched CollabStyles)  {
-	matched = CollabStyles{}
+func (c CollabStyles) Match(stylesToMatch CollabStyles) CollabStylesMatch {
+	matches := c.collectMatchesFor(stylesToMatch)
+	return CollabStylesMatch{
+		Matches: matches,
+		Score: c.calculateScore(matches),
+	}
+}
+
+func (c CollabStyles) collectMatchesFor(stylesToMatch CollabStyles) CollabStyles {
+	matches := CollabStyles{}
 	for _, style := range stylesToMatch {
 		if c.HasCollabStyle(style) {
-			matched = append(matched, style)
+			matches = append(matches, style)
 		}
 	}
-	return matched
+	return matches
+}
+
+func (c CollabStyles) calculateScore(matchedStyles CollabStyles) float64 {
+	return float64(len(matchedStyles)) / float64(len(c))
 }

--- a/internal/co_coders/criteria/collab_style_test.go
+++ b/internal/co_coders/criteria/collab_style_test.go
@@ -11,7 +11,8 @@ func TestMatchWithNoCollabStylesReturnsEmpty(t *testing.T) {
 
 	result := collabStyles.Match(noCollabStyles)
 
-	assert.Equal(t, noCollabStyles, result)
+	assert.Equal(t, noCollabStyles, result.Matches)
+	assert.Equal(t, 0.0, result.Score)
 }
 
 func TestMatchWithNoMatchingCollabStylesReturnsNoMatches(t *testing.T) {
@@ -20,7 +21,8 @@ func TestMatchWithNoMatchingCollabStylesReturnsNoMatches(t *testing.T) {
 
 	result := collabStyles.Match(stylesToMatch)
 
-	assert.Equal(t, CollabStyles{}, result)
+	assert.Equal(t, CollabStyles{}, result.Matches)
+	assert.Equal(t, 0.0, result.Score)
 }
 
 func TestMatchWithOneMatchingCollabStyleReturnsMatch(t *testing.T) {
@@ -28,7 +30,8 @@ func TestMatchWithOneMatchingCollabStyleReturnsMatch(t *testing.T) {
 
 	result := matchingCollabStyle.Match(matchingCollabStyle)
 
-	assert.Equal(t, matchingCollabStyle, result)
+	assert.Equal(t, matchingCollabStyle, result.Matches)
+	assert.Equal(t, 1.0, result.Score)
 }
 
 func TestMatchWithSubsetOfMatchingCollabStylesReturnsOnlyMatchingStyles(t *testing.T) {
@@ -37,5 +40,6 @@ func TestMatchWithSubsetOfMatchingCollabStylesReturnsOnlyMatchingStyles(t *testi
 
 	result := collabStyles.Match(stylesToMatch)
 
-	assert.Equal(t, CollabStyles{Pair}, result)
+	assert.Equal(t, CollabStyles{Pair}, result.Matches)
+	assert.Equal(t, 0.5, result.Score)
 }

--- a/internal/co_coders/criteria/criteria.go
+++ b/internal/co_coders/criteria/criteria.go
@@ -13,9 +13,8 @@ func New() Criteria {
 
 // Match ..
 func (c Criteria) Match(criteria Criteria) Matches {
-	collabStyleMatches := c.CollabStyles.Match(criteria.CollabStyles)
-	onCollabStylesScore := float64(len(collabStyleMatches)) / float64(len(c.CollabStyles))
-	return Matches{Score: onCollabStylesScore}
+	collabStylesMatch := c.CollabStyles.Match(criteria.CollabStyles)
+	return Matches{Score: collabStylesMatch.Score}
 }
 
 // Matches ..


### PR DESCRIPTION
It didn't make sense for criteria match to be calculating the score for collab style. It would have to do the same for all of the other criterions. Instead, it could just collect all the criterion matches together and then calculate the total score from those.

I've also moved the score test asserts into the collab style tests but I've left the criteria tests for now.