### PR TITLE
Refactor criterias to matchable

### DIFF
--- a/internal/co_coders/criteria/coding_language.go
+++ b/internal/co_coders/criteria/coding_language.go
@@ -1,12 +1,11 @@
 package criteria
 
 
-// NewCodingLanguage .. 
-func NewCodingLanguage(name string) NamedCriterion {
-	return NewNamedCriterion(name)
-} 
-
 // NewCodingLanguages ..
-func NewCodingLanguages(languages ...Criterion) NamedCriteria {
-	return NewNamedCriteria(languages...)
+func NewCodingLanguages(languages ...string) NamedCriteria {
+	criteria := []Criterion{}
+	for _, name := range languages {
+		criteria = append(criteria, NewNamedCriterion(name))
+	}
+	return NewNamedCriteria(criteria...)
 }

--- a/internal/co_coders/criteria/coding_language.go
+++ b/internal/co_coders/criteria/coding_language.go
@@ -1,45 +1,31 @@
 package criteria
 
-// CodingLanguage ..
-type CodingLanguage int
+import "fmt"
 
-// CodingLanguage constants
-const (
-	AssemblyLanguage CodingLanguage = iota
-	Bash
-	C 
-	Clojure
-	CPP
-	CSharp
-	Dart
-	Erlang
-	FSharp
-	Go
-	Haskell
-	Java
-	JavaScript
-	Kotlin
-	Lisp
-	ObjectiveC
-	ObjectPascal
-	Perl
-	PHP
-	Python
-	R
-	Ruby
-	Rust
-	Scala
-	Swift
-	SQL
-	TypeScript
-	VisualBasic
-)
+// CodingLanguage ..
+type CodingLanguage struct {
+	name string
+}
+
+// String ..
+func (c CodingLanguage) String() string {
+	return fmt.Sprintf("CodingLanguage{name: %s}", c.name)
+}
+
+// NewCodingLanguage .. 
+func NewCodingLanguage(name string) CodingLanguage {
+	return CodingLanguage{name: name}
+} 
 
 // CodingLanguages ..
 type CodingLanguages []CodingLanguage
 
-// HasCodingLanguage ..
-func (c CodingLanguages) HasCodingLanguage(targetLanguage CodingLanguage) bool {
+// NewCodingLanguages ..
+func NewCodingLanguages(languages ...CodingLanguage) CodingLanguages {
+	return append(CodingLanguages{}, languages...)
+}
+
+func (c CodingLanguages) has(targetLanguage CodingLanguage) bool {
 	for _, language := range c {
 		if language == targetLanguage {
 			return true
@@ -49,10 +35,16 @@ func (c CodingLanguages) HasCodingLanguage(targetLanguage CodingLanguage) bool {
 }
 
 // Match ..
-func (c CodingLanguages) Match(targetLanguages CodingLanguages) CodingLanguages {
-	matches := CodingLanguages{}
-	for _, language := range targetLanguages {
-		if c.HasCodingLanguage(language){
+func (c CodingLanguages) Match(targetLanguages Matchable) []Criterion {
+	matches := []Criterion{}
+
+	languages, ok := targetLanguages.(CodingLanguages)
+	if !ok {
+		return matches
+	}
+
+	for _, language := range languages {
+		if c.has(language){
 			matches = append(matches, language)
 		}
 	}

--- a/internal/co_coders/criteria/coding_language.go
+++ b/internal/co_coders/criteria/coding_language.go
@@ -1,52 +1,12 @@
 package criteria
 
-import "fmt"
-
-// CodingLanguage ..
-type CodingLanguage struct {
-	name string
-}
-
-// String ..
-func (c CodingLanguage) String() string {
-	return fmt.Sprintf("CodingLanguage{name: %s}", c.name)
-}
 
 // NewCodingLanguage .. 
-func NewCodingLanguage(name string) CodingLanguage {
-	return CodingLanguage{name: name}
+func NewCodingLanguage(name string) NamedCriterion {
+	return NewNamedCriterion(name)
 } 
 
-// CodingLanguages ..
-type CodingLanguages []CodingLanguage
-
 // NewCodingLanguages ..
-func NewCodingLanguages(languages ...CodingLanguage) CodingLanguages {
-	return append(CodingLanguages{}, languages...)
-}
-
-func (c CodingLanguages) has(targetLanguage CodingLanguage) bool {
-	for _, language := range c {
-		if language == targetLanguage {
-			return true
-		}
-	}
-	return false
-}
-
-// Match ..
-func (c CodingLanguages) Match(targetLanguages Matchable) []Criterion {
-	matches := []Criterion{}
-
-	languages, ok := targetLanguages.(CodingLanguages)
-	if !ok {
-		return matches
-	}
-
-	for _, language := range languages {
-		if c.has(language){
-			matches = append(matches, language)
-		}
-	}
-	return matches
+func NewCodingLanguages(languages ...Criterion) NamedCriteria {
+	return NewNamedCriteria(languages...)
 }

--- a/internal/co_coders/criteria/coding_language.go
+++ b/internal/co_coders/criteria/coding_language.go
@@ -3,9 +3,5 @@ package criteria
 
 // NewCodingLanguages ..
 func NewCodingLanguages(languages ...string) NamedCriteria {
-	criteria := []Criterion{}
-	for _, name := range languages {
-		criteria = append(criteria, NewNamedCriterion(name))
-	}
-	return NewNamedCriteria(criteria...)
+	return NewNamedCriteria(languages...)
 }

--- a/internal/co_coders/criteria/coding_language_test.go
+++ b/internal/co_coders/criteria/coding_language_test.go
@@ -5,38 +5,38 @@ import (
 	"testing"
 )
 
-var (
-	C = NewCodingLanguage("C")
-	CSharp = NewCodingLanguage("C#")
-	Go = NewCodingLanguage("Go")
-	Java = NewCodingLanguage("Java")
-	JavaScript = NewCodingLanguage("JavaScript")
-	Python = NewCodingLanguage("Python")	
-)
-
 func TestMatchWithNoCodingLanguagesReturnsEmpty(t *testing.T){
-	codingLanguages := NewCodingLanguages(Java)
+	codingLanguages := NewCodingLanguages("Java")
 	noCodingLanguages := NewCodingLanguages()
 
 	result := codingLanguages.Match(noCodingLanguages)
 
-	assert.Equal(t, []Criterion{}, result)
+	assert.Equal(t, generateNamedMatches(), result)
 }
 
 func TestMatchWithOneMatchingCodingLanguageReturnsOneMatch(t *testing.T){
-	codingLanguages := NewCodingLanguages(Python)
-	matchingCodingLanguages := NewCodingLanguages(Python)
+	codingLanguages := NewCodingLanguages("Python")
+	matchingCodingLanguages := NewCodingLanguages("Python")
 
 	result := codingLanguages.Match(matchingCodingLanguages)
 
-	assert.Equal(t, []Criterion{Python}, result)
+	assert.Equal(t, generateNamedMatches("Python"), result)
 }
 
 func TestMatchWithOneSomeMatchingCodingLanguagesReturnsOnlyMatches(t *testing.T){
-	codingLanguages := NewCodingLanguages(CSharp, JavaScript, Go)
-	matchingCodingLanguages := NewCodingLanguages(C, CSharp, JavaScript)
+	codingLanguages := NewCodingLanguages("C#", "JavaScript", "Go")
+	matchingCodingLanguages := NewCodingLanguages("C", "C#", "JavaScript")
 
 	result := codingLanguages.Match(matchingCodingLanguages)
 
-	assert.Equal(t, []Criterion{CSharp, JavaScript}, result)
+	assert.Equal(t, generateNamedMatches("C#", "JavaScript"), result)
+}
+
+
+func generateNamedMatches(names ...string) []Criterion {
+	criteria := []Criterion{}
+	for _, name := range names {
+		criteria = append(criteria, NewNamedCriterion(name))
+	}	
+	return criteria
 }

--- a/internal/co_coders/criteria/coding_language_test.go
+++ b/internal/co_coders/criteria/coding_language_test.go
@@ -5,29 +5,38 @@ import (
 	"testing"
 )
 
+var (
+	C = NewCodingLanguage("C")
+	CSharp = NewCodingLanguage("C#")
+	Go = NewCodingLanguage("Go")
+	Java = NewCodingLanguage("Java")
+	JavaScript = NewCodingLanguage("JavaScript")
+	Python = NewCodingLanguage("Python")	
+)
+
 func TestMatchWithNoCodingLanguagesReturnsEmpty(t *testing.T){
-	codingLanguages := CodingLanguages{Java}
-	noCodingLanguages := CodingLanguages{}
+	codingLanguages := NewCodingLanguages(Java)
+	noCodingLanguages := NewCodingLanguages()
 
 	result := codingLanguages.Match(noCodingLanguages)
 
-	assert.Equal(t, noCodingLanguages, result)
+	assert.Equal(t, []Criterion{}, result)
 }
 
 func TestMatchWithOneMatchingCodingLanguageReturnsOneMatch(t *testing.T){
-	codingLanguages := CodingLanguages{Python}
-	matchingCodingLanguages := CodingLanguages{Python}
+	codingLanguages := NewCodingLanguages(Python)
+	matchingCodingLanguages := NewCodingLanguages(Python)
 
 	result := codingLanguages.Match(matchingCodingLanguages)
 
-	assert.Equal(t, matchingCodingLanguages, result)
+	assert.Equal(t, []Criterion{Python}, result)
 }
 
 func TestMatchWithOneSomeMatchingCodingLanguagesReturnsOnlyMatches(t *testing.T){
-	codingLanguages := CodingLanguages{CSharp, JavaScript, Go}
-	matchingCodingLanguages := CodingLanguages{C, CSharp, JavaScript}
+	codingLanguages := NewCodingLanguages(CSharp, JavaScript, Go)
+	matchingCodingLanguages := NewCodingLanguages(C, CSharp, JavaScript)
 
 	result := codingLanguages.Match(matchingCodingLanguages)
 
-	assert.Equal(t, CodingLanguages{CSharp, JavaScript}, result)
+	assert.Equal(t, []Criterion{CSharp, JavaScript}, result)
 }

--- a/internal/co_coders/criteria/collab_style.go
+++ b/internal/co_coders/criteria/collab_style.go
@@ -1,12 +1,11 @@
 package criteria
 
 
-// NewCollabStyle ...
-func NewCollabStyle(name string) NamedCriterion {
-	return NewNamedCriterion(name)
-}
-
 // NewCollabStyles ..
-func NewCollabStyles(styles ...Criterion) NamedCriteria {
-	return NewNamedCriteria(styles...)
+func NewCollabStyles(styles ...string) NamedCriteria {
+	criteria := []Criterion{}
+	for _, name := range styles {
+		criteria = append(criteria, NewNamedCriterion(name))
+	}
+	return NewNamedCriteria(criteria...)
 }

--- a/internal/co_coders/criteria/collab_style.go
+++ b/internal/co_coders/criteria/collab_style.go
@@ -1,20 +1,32 @@
 package criteria
 
-// CollabStyle ..
-type CollabStyle int
+import "fmt"
 
-// CollabStyle Constants ..
-const (
-	Team CollabStyle = iota + 1
-	Pair
-	Mob
-)
+// CollabStyle ..
+type CollabStyle struct {
+	name string 
+}
+
+// String ..
+func (c CollabStyle) String() string {
+	return fmt.Sprintf("CollabStyle{name: %s}", c.name)
+}
+
+// NewCollabStyle ...
+func NewCollabStyle(name string) CollabStyle {
+	return CollabStyle{name: name}
+}
 
 // CollabStyles ..
 type CollabStyles []CollabStyle
 
+// NewCollabStyles ..
+func NewCollabStyles(styles ...CollabStyle) CollabStyles {
+	return append(CollabStyles{}, styles...)
+}
+
 // HasCollabStyle ..
-func (c CollabStyles) HasCollabStyle(collabStyle CollabStyle) bool {
+func (c CollabStyles) has(collabStyle CollabStyle) bool {
 	for _, style := range c {
 		if style == collabStyle {
 			return true
@@ -24,12 +36,18 @@ func (c CollabStyles) HasCollabStyle(collabStyle CollabStyle) bool {
 }
 
 // Match ..
-func (c CollabStyles) Match(stylesToMatch CollabStyles) (matched CollabStyles)  {
-	matched = CollabStyles{}
-	for _, style := range stylesToMatch {
-		if c.HasCollabStyle(style) {
-			matched = append(matched, style)
+func (c CollabStyles) Match(targetStyles Matchable) (matches []Criterion)  {
+	matches = []Criterion{}
+	styles, ok := targetStyles.(CollabStyles)
+
+	if !ok {
+		return matches
+	}
+
+	for _, style := range styles {
+		if c.has(style) {
+			matches = append(matches, style)
 		}
 	}
-	return matched
+	return matches
 }

--- a/internal/co_coders/criteria/collab_style.go
+++ b/internal/co_coders/criteria/collab_style.go
@@ -1,53 +1,12 @@
 package criteria
 
-import "fmt"
-
-// CollabStyle ..
-type CollabStyle struct {
-	name string 
-}
-
-// String ..
-func (c CollabStyle) String() string {
-	return fmt.Sprintf("CollabStyle{name: %s}", c.name)
-}
 
 // NewCollabStyle ...
-func NewCollabStyle(name string) CollabStyle {
-	return CollabStyle{name: name}
+func NewCollabStyle(name string) NamedCriterion {
+	return NewNamedCriterion(name)
 }
-
-// CollabStyles ..
-type CollabStyles []CollabStyle
 
 // NewCollabStyles ..
-func NewCollabStyles(styles ...CollabStyle) CollabStyles {
-	return append(CollabStyles{}, styles...)
-}
-
-// HasCollabStyle ..
-func (c CollabStyles) has(collabStyle CollabStyle) bool {
-	for _, style := range c {
-		if style == collabStyle {
-			return true
-		}
-	}
-	return false
-}
-
-// Match ..
-func (c CollabStyles) Match(targetStyles Matchable) (matches []Criterion)  {
-	matches = []Criterion{}
-	styles, ok := targetStyles.(CollabStyles)
-
-	if !ok {
-		return matches
-	}
-
-	for _, style := range styles {
-		if c.has(style) {
-			matches = append(matches, style)
-		}
-	}
-	return matches
+func NewCollabStyles(styles ...Criterion) NamedCriteria {
+	return NewNamedCriteria(styles...)
 }

--- a/internal/co_coders/criteria/collab_style.go
+++ b/internal/co_coders/criteria/collab_style.go
@@ -3,9 +3,5 @@ package criteria
 
 // NewCollabStyles ..
 func NewCollabStyles(styles ...string) NamedCriteria {
-	criteria := []Criterion{}
-	for _, name := range styles {
-		criteria = append(criteria, NewNamedCriterion(name))
-	}
-	return NewNamedCriteria(criteria...)
+	return NewNamedCriteria(styles...)
 }

--- a/internal/co_coders/criteria/collab_style_test.go
+++ b/internal/co_coders/criteria/collab_style_test.go
@@ -5,43 +5,37 @@ import (
 	"testing"
 )
 
-var (
-	Team = NewCollabStyle("Team")
-	Pair = NewCollabStyle("Pair")
-	Mob = NewCollabStyle("Mob")
-)
-
 func TestMatchWithNoCollabStylesReturnsEmpty(t *testing.T) {
-	collabStyles := NewCollabStyles(Team)
+	collabStyles := NewCollabStyles("Team")
 	noCollabStyles := NewCollabStyles()
 
 	result := collabStyles.Match(noCollabStyles)
 
-	assert.Equal(t, []Criterion{}, result)
+	assert.Equal(t, generateNamedMatches(), result)
 }
 
 func TestMatchWithNoMatchingCollabStylesReturnsNoMatches(t *testing.T) {
-	collabStyles := NewCollabStyles(Team)
-	stylesToMatch := NewCollabStyles(Mob)
+	collabStyles := NewCollabStyles("Team")
+	stylesToMatch := NewCollabStyles("Mob")
 
 	result := collabStyles.Match(stylesToMatch)
 
-	assert.Equal(t, []Criterion{}, result)
+	assert.Equal(t, generateNamedMatches(), result)
 }
 
 func TestMatchWithOneMatchingCollabStyleReturnsMatch(t *testing.T) {
-	matchingCollabStyle := NewCollabStyles(Team)
+	matchingCollabStyle := NewCollabStyles("Team")
 
 	result := matchingCollabStyle.Match(matchingCollabStyle)
 
-	assert.Equal(t, []Criterion{Team}, result)
+	assert.Equal(t, generateNamedMatches("Team"), result)
 }
 
 func TestMatchWithSubsetOfMatchingCollabStylesReturnsOnlyMatchingStyles(t *testing.T) {
-	collabStyles := NewCollabStyles(Team, Pair)
-	stylesToMatch := NewCollabStyles(Pair, Mob)
+	collabStyles := NewCollabStyles("Team", "Pair")
+	stylesToMatch := NewCollabStyles("Pair", "Mob")
 
 	result := collabStyles.Match(stylesToMatch)
 
-	assert.Equal(t, []Criterion{Pair}, result)
+	assert.Equal(t, generateNamedMatches("Pair"), result)
 }

--- a/internal/co_coders/criteria/collab_style_test.go
+++ b/internal/co_coders/criteria/collab_style_test.go
@@ -5,37 +5,43 @@ import (
 	"testing"
 )
 
+var (
+	Team = NewCollabStyle("Team")
+	Pair = NewCollabStyle("Pair")
+	Mob = NewCollabStyle("Mob")
+)
+
 func TestMatchWithNoCollabStylesReturnsEmpty(t *testing.T) {
-	collabStyles := CollabStyles{Team}
-	noCollabStyles := CollabStyles{}
+	collabStyles := NewCollabStyles(Team)
+	noCollabStyles := NewCollabStyles()
 
 	result := collabStyles.Match(noCollabStyles)
 
-	assert.Equal(t, noCollabStyles, result)
+	assert.Equal(t, []Criterion{}, result)
 }
 
 func TestMatchWithNoMatchingCollabStylesReturnsNoMatches(t *testing.T) {
-	collabStyles := CollabStyles{Team}
-	stylesToMatch := CollabStyles{Mob}
+	collabStyles := NewCollabStyles(Team)
+	stylesToMatch := NewCollabStyles(Mob)
 
 	result := collabStyles.Match(stylesToMatch)
 
-	assert.Equal(t, CollabStyles{}, result)
+	assert.Equal(t, []Criterion{}, result)
 }
 
 func TestMatchWithOneMatchingCollabStyleReturnsMatch(t *testing.T) {
-	matchingCollabStyle := CollabStyles{Team}
+	matchingCollabStyle := NewCollabStyles(Team)
 
 	result := matchingCollabStyle.Match(matchingCollabStyle)
 
-	assert.Equal(t, matchingCollabStyle, result)
+	assert.Equal(t, []Criterion{Team}, result)
 }
 
 func TestMatchWithSubsetOfMatchingCollabStylesReturnsOnlyMatchingStyles(t *testing.T) {
-	collabStyles := CollabStyles{Team, Pair}
-	stylesToMatch := CollabStyles{Pair, Mob}
+	collabStyles := NewCollabStyles(Team, Pair)
+	stylesToMatch := NewCollabStyles(Pair, Mob)
 
 	result := collabStyles.Match(stylesToMatch)
 
-	assert.Equal(t, CollabStyles{Pair}, result)
+	assert.Equal(t, []Criterion{Pair}, result)
 }

--- a/internal/co_coders/criteria/criteria.go
+++ b/internal/co_coders/criteria/criteria.go
@@ -3,12 +3,12 @@ package criteria
 
 // Criteria ..
 type Criteria struct {
-	CollabStyles CollabStyles
+	CollabStyles NamedCriteria
 }
 
 // New ...
 func New() Criteria {
-	return Criteria{CollabStyles:CollabStyles{}}
+	return Criteria{CollabStyles:NewCollabStyles()}
 }
 
 // Match ..
@@ -22,14 +22,3 @@ func (c Criteria) Match(criteria Criteria) Matches {
 type Matches struct {
 	Score float64
 }
-
-// Criterion ..
-type Criterion interface {
-	String() string
-}
-
-// Matchable ..
-type Matchable interface {
-	Match(m Matchable) []Criterion
-}
-

--- a/internal/co_coders/criteria/criteria_test.go
+++ b/internal/co_coders/criteria/criteria_test.go
@@ -7,8 +7,8 @@ import (
 
 
 func TestMatchHasAScore(t *testing.T) {
-	criteria := Criteria{CollabStyles:  NewCollabStyles(Team)}
-	allMatchCriteria := Criteria{CollabStyles:  NewCollabStyles(Team)}
+	criteria := Criteria{CollabStyles:  NewCollabStyles("Team")}
+	allMatchCriteria := Criteria{CollabStyles:  NewCollabStyles("Team")}
 
 	result := criteria.Match(allMatchCriteria)
 
@@ -16,8 +16,8 @@ func TestMatchHasAScore(t *testing.T) {
 }
 
 func TestMatchHasAScoreOfZeroWithNoMatch(t *testing.T) {
-	criteria := Criteria{CollabStyles: NewCollabStyles(Pair)}
-	noMatchCriteria := Criteria{CollabStyles:  NewCollabStyles(Team)}
+	criteria := Criteria{CollabStyles: NewCollabStyles("Pair")}
+	noMatchCriteria := Criteria{CollabStyles:  NewCollabStyles("Team")}
 
 	result := criteria.Match(noMatchCriteria)
 
@@ -25,8 +25,8 @@ func TestMatchHasAScoreOfZeroWithNoMatch(t *testing.T) {
 }
 
 func TestMatchScore50Percent(t *testing.T) {
-	criteria := Criteria{CollabStyles:  NewCollabStyles(Pair, Mob)}
-	halfMatchCriteria := Criteria{CollabStyles:  NewCollabStyles(Mob)}
+	criteria := Criteria{CollabStyles:  NewCollabStyles("Pair", "Mob")}
+	halfMatchCriteria := Criteria{CollabStyles:  NewCollabStyles("Mob")}
 
 	result := criteria.Match(halfMatchCriteria)
 
@@ -35,8 +35,8 @@ func TestMatchScore50Percent(t *testing.T) {
 
 func TestMatchForTimeZoneCollabStyleAndCodingLanguage(t *testing.T){
 	tz := NewTimeZoneRange(0.0, 0.0)
-	cs := NewCollabStyles(Pair, Team)
-	cl := NewCodingLanguages(JavaScript, Java)
+	cs := NewCollabStyles("Pair", "Team")
+	cl := NewCodingLanguages("JavaScript", "Java")
 	criteria := NewCriteria(tz, cl , cs)
 	assert.Equal(t, criteria, criteria)
 }

--- a/internal/co_coders/criteria/criteria_test.go
+++ b/internal/co_coders/criteria/criteria_test.go
@@ -35,18 +35,13 @@ func TestMatchScore50Percent(t *testing.T) {
 
 func TestMatchForTimeZoneCollabStyleAndCodingLanguage(t *testing.T){
 	tz := NewTimeZoneRange(0.0, 0.0)
-	//cs := NewCollabStyles(Pair, Team)
+	cs := NewCollabStyles(Pair, Team)
 	cl := NewCodingLanguages(JavaScript, Java)
-	criteria := NewCriteria(tz, cl /*, cs*/)
+	criteria := NewCriteria(tz, cl , cs)
 	assert.Equal(t, criteria, criteria)
-}
-
-
-
-func NewCollabStyles(styles ...CollabStyle) CollabStyles {
-	return append(CollabStyles{}, styles...)
 }
 
 func NewCriteria(matchables ...Matchable) Criteria {
 	return New()
 }
+

--- a/internal/co_coders/criteria/criteria_test.go
+++ b/internal/co_coders/criteria/criteria_test.go
@@ -36,14 +36,12 @@ func TestMatchScore50Percent(t *testing.T) {
 func TestMatchForTimeZoneCollabStyleAndCodingLanguage(t *testing.T){
 	tz := NewTimeZoneRange(0.0, 0.0)
 	//cs := NewCollabStyles(Pair, Team)
-	//cl := NewCodingLanguages(JavaScript, Java)
-	criteria := NewCriteria(tz /* cs, cl*/)
+	cl := NewCodingLanguages(JavaScript, Java)
+	criteria := NewCriteria(tz, cl /*, cs*/)
 	assert.Equal(t, criteria, criteria)
 }
 
-func NewCodingLanguages(languages ...CodingLanguage) CodingLanguages {
-	return append(CodingLanguages{}, languages...)
-}
+
 
 func NewCollabStyles(styles ...CollabStyle) CollabStyles {
 	return append(CollabStyles{}, styles...)

--- a/internal/co_coders/criteria/criteria_test.go
+++ b/internal/co_coders/criteria/criteria_test.go
@@ -7,8 +7,8 @@ import (
 
 
 func TestMatchHasAScore(t *testing.T) {
-	criteria := Criteria{CollabStyles: CollabStyles{Team}}
-	allMatchCriteria := Criteria{CollabStyles: CollabStyles{Team}}
+	criteria := Criteria{CollabStyles:  NewCollabStyles(Team)}
+	allMatchCriteria := Criteria{CollabStyles:  NewCollabStyles(Team)}
 
 	result := criteria.Match(allMatchCriteria)
 
@@ -16,8 +16,8 @@ func TestMatchHasAScore(t *testing.T) {
 }
 
 func TestMatchHasAScoreOfZeroWithNoMatch(t *testing.T) {
-	criteria := Criteria{CollabStyles: CollabStyles{Pair}}
-	noMatchCriteria := Criteria{CollabStyles: CollabStyles{Team}}
+	criteria := Criteria{CollabStyles: NewCollabStyles(Pair)}
+	noMatchCriteria := Criteria{CollabStyles:  NewCollabStyles(Team)}
 
 	result := criteria.Match(noMatchCriteria)
 
@@ -25,8 +25,8 @@ func TestMatchHasAScoreOfZeroWithNoMatch(t *testing.T) {
 }
 
 func TestMatchScore50Percent(t *testing.T) {
-	criteria := Criteria{CollabStyles: CollabStyles{Pair, Mob}}
-	halfMatchCriteria := Criteria{CollabStyles: CollabStyles{Mob}}
+	criteria := Criteria{CollabStyles:  NewCollabStyles(Pair, Mob)}
+	halfMatchCriteria := Criteria{CollabStyles:  NewCollabStyles(Mob)}
 
 	result := criteria.Match(halfMatchCriteria)
 
@@ -44,4 +44,3 @@ func TestMatchForTimeZoneCollabStyleAndCodingLanguage(t *testing.T){
 func NewCriteria(matchables ...Matchable) Criteria {
 	return New()
 }
-

--- a/internal/co_coders/criteria/criterion.go
+++ b/internal/co_coders/criteria/criterion.go
@@ -32,7 +32,11 @@ type NamedCriteria []Criterion
 
 
 // NewNamedCriteria ...
-func NewNamedCriteria(criteria ...Criterion) NamedCriteria {
+func NewNamedCriteria(names ...string) NamedCriteria {
+	criteria := []Criterion{}
+	for _, name := range names {
+		criteria = append(criteria, NewNamedCriterion(name))
+	}
 	return append(NamedCriteria{}, criteria...)
 }
 

--- a/internal/co_coders/criteria/criterion.go
+++ b/internal/co_coders/criteria/criterion.go
@@ -1,0 +1,64 @@
+package criteria
+
+import "fmt"
+
+// Criterion ..
+type Criterion interface {
+	String() string
+}
+
+// Matchable ..
+type Matchable interface {
+	Match(m Matchable) []Criterion
+}
+
+// NamedCriterion ..
+type NamedCriterion struct{
+	name string
+}
+
+// NewNamedCriterion ..
+func NewNamedCriterion(name string) NamedCriterion {
+	return NamedCriterion{name: name}
+}
+
+// String ..
+func (c NamedCriterion) String() string {
+	return fmt.Sprintf("NamedCriterion{name: %s}", c.name)
+}
+
+// NamedCriteria ...
+type NamedCriteria []Criterion 
+
+
+// NewNamedCriteria ...
+func NewNamedCriteria(criteria ...Criterion) NamedCriteria {
+	return append(NamedCriteria{}, criteria...)
+}
+
+func (c NamedCriteria) has(targetCriterion Criterion) bool {
+	for _, criterion := range c {
+		if criterion == targetCriterion {
+			return true
+		}
+	}
+	return false
+}
+
+// Match ..
+func (c NamedCriteria) Match(targetCriteria Matchable) []Criterion {
+	matches := []Criterion{}
+	criteria, ok := targetCriteria.(NamedCriteria)
+
+	if !ok {
+		return matches
+	}
+	
+	for _, criteria := range criteria {
+		if c.has(criteria){
+			matches = append(matches, criteria)
+		}
+	}
+	
+	return matches
+}

--- a/internal/co_coders/criteria/criterion_test.go
+++ b/internal/co_coders/criteria/criterion_test.go
@@ -1,0 +1,25 @@
+package criteria
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNamedCriterionCreatesAString(t *testing.T){
+	criterion := NewNamedCriterion("Name")
+	assert.Equal(t, "NamedCriterion{name: Name}", criterion.String())
+}
+
+
+func TestNamedCriteriaReturnsEmptyIfTheMatchableIsNotANamedCriteria(t *testing.T){
+	namedCriteria := NewNamedCriteria("One", "Two", "Three")
+	result := namedCriteria.Match(intCriteria{1, 2, 3})
+	assert.Equal(t, generateNamedMatches(), result)
+}
+
+type intCriteria []int
+
+func (i intCriteria) Match(m Matchable) []Criterion {
+	return []Criterion{}
+}


### PR DESCRIPTION
All three criteria now have the same matchable interface. I also managed to create a common abstraction for CodingLanguage and CollabStyle. I've kept all the current tests but it's possible that we can get rid of some of them.
